### PR TITLE
[composer] Remove useless/harmful fields, fix autoload definition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,18 +17,9 @@
     }
   ],
 
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "https://github.com/tumblr/tumblr.php"
-    }
-  ],
-
   "license": "Apache-2.0",
 
   "type": "library",
-
-  "version": "0.0.2",
 
   "require": {
     "eher/oauth": "1.0.*",
@@ -41,7 +32,7 @@
 
   "autoload": {
     "psr-0": {
-      "Tumblr\\API": "lib/Tumblr/API"
+      "Tumblr\\API": "lib"
     }
   }
 


### PR DESCRIPTION
- Version will give you problems when you want to actually tag a
    release and the versions don't match up.
- Repositories do not to what you think they do. See also the composer
    docs.
- The autoload definition was broken. See also composer docs, PSR-0
    spec.

This PR was triggered by this StackOverflow question:
http://stackoverflow.com/q/15451371
