### PR TITLE
 remove require_once of classes 

### DIFF
--- a/lib/Tumblr/API/Client.php
+++ b/lib/Tumblr/API/Client.php
@@ -2,9 +2,6 @@
 
 namespace Tumblr\API;
 
-require_once(__DIR__ . '/RequestHandler.php');
-require_once(__DIR__ . '/RequestException.php');
-
 /**
  * A client to access the Tumblr API
  */


### PR DESCRIPTION
since we have these two classes are in the same namespace Tumblr\API, you don't need to require them, PHP can do it for you.
