### PR TITLE
Allow OAuth endpoints on www.tumblr.com using RequestHandler

### DIFF
--- a/lib/Tumblr/API/RequestHandler.php
+++ b/lib/Tumblr/API/RequestHandler.php
@@ -65,7 +65,11 @@ class RequestHandler
         unset($options['data']);
 
         // Get the oauth signature to put in the request header
-        $url = "http://api.tumblr.com/$path";
+        if (strpos($path, 'https://') === 0 || strpos($path, 'http://') === 0) {
+            $url = $path;
+        } else {
+            $url = "http://api.tumblr.com/$path";
+        }
         $oauth = \Eher\OAuth\Request::from_consumer_and_token(
             $this->consumer, $this->token,
             $method, $url, $options


### PR DESCRIPTION
RequestHandler: Do not insert "http://api.tumblr.com/" to the given path if the path is already a full url. This allows us to use it for OAuth endpoints (e.g. oauth/request_token). These endpoints are on "www.tumblr.com" and not on the "api" subdomain. Example usage:

```
$req = $client->requestHandler->request('POST', 'http://www.tumblr.com/oauth/request_token', [
  'oauth_callback' => '...',
]);
```
