### PR TITLE
RequestHandler: Allow setting of the `baseUrl` to use. 

### DIFF
--- a/lib/Tumblr/API/RequestHandler.php
+++ b/lib/Tumblr/API/RequestHandler.php
@@ -66,16 +66,6 @@ class RequestHandler
     }
 
     /**
-     * Return the base url for this request handler.
-     *
-     * @return string
-     */
-    public function getBaseUrl()
-    {
-        return $this->baseUrl;
-    }
-
-    /**
      * Make a request with this request handler
      *
      * @param string $method  one of GET, POST


### PR DESCRIPTION
This allows us to use it for OAuth endpoints (e.g. oauth/request_token). These endpoints are on "www.tumblr.com" and not on the "api" subdomain. Example usage:

```
$client->getRequestHandler()->setBaseUrl('http://www.tumblr.com/');
$req = $client->getRequestHandler()->request('POST', 'oauth/request_token', [
  'oauth_callback' => '...',
]);
```

The default `baseUrl` is "http://api.tumblr.com/".
