### PR TITLE
Also print response error.

### DIFF
--- a/lib/Tumblr/API/RequestException.php
+++ b/lib/Tumblr/API/RequestException.php
@@ -11,7 +11,16 @@ class RequestException extends \Exception
     public function __construct($response)
     {
         $error = json_decode($response->body);
-        $errstr = isset($error->meta) ? $error->meta->msg : 'Unknown Error';
+        $errstr = 'Unknown Error';
+        if(isset($error->meta)){
+            $errstr = $error->meta->msg;
+            if(isset($error->response->errors)){
+                $errstr .= ' ('.$error->response->errors[0].')';
+            }
+        }
+        elseif(isset($error->response->errors)){
+            $errstr = $error->response->errors[0];
+        }
 
         $this->statusCode = $response->status;
         $this->message = $errstr;


### PR DESCRIPTION
For better debugging print the first error of the response.

See also http://stackoverflow.com/questions/18217439/bad-request-response-on-tumblrs-api-quote-request.
