### PR TITLE
Fix for multiple photos

### DIFF
--- a/lib/Tumblr/API/Client.php
+++ b/lib/Tumblr/API/Client.php
@@ -408,7 +408,7 @@ class Client
             $sources = $options['source'];
             unset($options['source']);
             foreach ($sources as $i => $source) {
-                $options["source[$i]"] = $source;
+                $options["data"][] = $source;
             }
         }
 


### PR DESCRIPTION
Data variable must be given as an array in order for RequestHandler to
manage it correctly
