### PR TITLE
Update to Guzzle 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ before_script: composer install
 php:
   - 5.6
   - 5.5
-  - 5.4
-  - 5.3
   - hhvm
 
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: php
 before_script: composer install
 
 php:
+  - 7.1
+  - 7.0
   - 5.6
-  - 5.5
   - hhvm
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $client->getTaggedPosts($tag, $options = null);
 tumblr.php is available
 [on composer](https://packagist.org/packages/tumblr/tumblr)
 
-* guzzle/guzzle >=3.1.x,<4 
+* guzzle/guzzle 6.*
 * eher/oauth 1.0.x
 
 If you're using composer (you should!) you can just run

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 
   "require": {
     "eher/oauth": "1.0.*",
-    "guzzle/guzzle": ">=3.1.0,<4"
+    "guzzlehttp/guzzle": "6.*"
   },
 
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   },
 
   "require-dev": {
-    "phpunit/phpunit": "*"
+    "phpunit/phpunit": "5.3.*"
   },
 
   "autoload": {


### PR DESCRIPTION
### Description

Migrate to Guzzle v6 from v3. All interfaces remain identical, but the underlying implemention uses Guzzle and PSR-7. Also add some additional tests for parsing API responses.

Fixes #53
### Testing

Unit tests have been updated to use Guzzle 6. Also, some almost-integration tests I ran to make sure everything was still happy:

``` php
// GET requests
$response = $client->getBlogPosts('david.tumblr.com');
echo substr(json_encode($response), 0 ,200) . "\n";

$response = $client->getUserInfo();
echo substr(json_encode($response), 0 ,200) . "\n";

// POST no body
$response = $client->like(1, 'Os456LBL');
echo substr(json_encode($response), 0 ,200) . "\n";

try {
    $response = $client->like(1, 'asdf');
} catch (Exception $e) {
    echo $e->getMessage() . "\n";
}


// POST form-encoded
$response = $client->createPost('ceyko.tumblr.com', [ 'type' => 'text', 'body' => 'Text post from tumblr.php' ]);
echo substr(json_encode($response), 0 ,200) . "\n";

try {
    $client->createPost('myblog.tumblr.com', [ 'type' => 'fake' ]);
} catch (Exception $e) {
    echo $e->getMessage() . "\n";
}


// POST multi-part
$response = $client->createPost('ceyko.tumblr.com', [ 'type' => 'photo', 'caption' => 'Photo post from tumblr.php', 'data' => '/path/to/file' ]);
echo substr(json_encode($response), 0 ,200) . "\n";

$response = $client->createPost('ceyko.tumblr.com', [ 'type' => 'photo', 'caption' => 'Photoset from tumblr.php', 'data' => [ '/path/to/file/1', '/path/to/file/2' ] ]);
echo substr(json_encode($response), 0 ,200) . "\n";
```

@codingjester @seejohnrun @komapa 
