### PR TITLE
Update RequestException.php to better handle non-array error responses

### DIFF
--- a/lib/Tumblr/API/RequestException.php
+++ b/lib/Tumblr/API/RequestException.php
@@ -16,7 +16,11 @@ class RequestException extends \Exception
         if (isset($error->meta)) {
             $errstr = $error->meta->msg;
             if (isset($error->response->errors)) {
-                $errstr .= ' ('.$error->response->errors[0].')';
+                if (is_array($error->response->errors) && count($error->response->errors)) {
+                    $errstr .= ' ('.$error->response->errors[0].')';
+                } else {
+                    $errstr .= ' ('.$error->response->errors.')';
+                }                
             }
         } elseif (isset($error->response->errors)) {
             $errstr = $error->response->errors[0];


### PR DESCRIPTION
It is possible for the response to not be an array, but a single string. This patch handles that case.