### PR TITLE
Redirects now return code 302

### DIFF
--- a/lib/Tumblr/API/Client.php
+++ b/lib/Tumblr/API/Client.php
@@ -440,7 +440,7 @@ class Client
     private function getRedirect($path, $options, $addApiKey)
     {
         $response = $this->makeRequest('GET', $path, $options, $addApiKey);
-        if ($response->status === 301) {
+        if ($response->status === 301 || $response->status === 302) {
             return $response->headers['Location'][0];
         }
 


### PR DESCRIPTION
The code is expecting redirects to send code 301, but they now send 302

Fixes #87 

## Testing
```php
<?php
require_once 'vendor/autoload.php';

$client = new Tumblr\API\Client(
    '...key...',
    '...secret...'
);
$avatar = $client->getBlogAvatar('david', 96);

var_dump($avatar);
```