### PR TITLE
fixing video uploads

### DIFF
--- a/lib/Tumblr/API/RequestHandler.php
+++ b/lib/Tumblr/API/RequestHandler.php
@@ -125,12 +125,22 @@ class RequestHandler
                         'contents'  => $contents,
                     ];
                 }
-                foreach ((array) $file as $idx => $path) {
+                if ($options['type'] === 'video') {
+                    // to assure that only one video get uploaded
+                    $file = (array) $file;
                     $form[] = [
-                        'name'      => "data[$idx]",
-                        'contents'  => file_get_contents($path),
+                        'name'      => "data", // not creating array of files
+                        'contents'  => file_get_contents($file[0]),
                         'filename'  => pathinfo($path, PATHINFO_FILENAME),
                     ];
+                } else {
+                    foreach ((array) $file as $idx => $path) {
+                        $form[] = [
+                            'name'      => "data[$idx]",
+                            'contents'  => file_get_contents($path),
+                            'filename'  => pathinfo($path, PATHINFO_FILENAME),
+                        ];
+                    }
                 }
                 $guzzleOptions['multipart'] = $form;
             }


### PR DESCRIPTION
Fixed the issue related to posting a video post on Tumblr.
A video post can be uploaded as follows:
```php
$client = new Tumblr\API\Client($consumerKey, $consumerSecret);
$client->setToken($token, $tokenSecret);
$post_data = array('type' => 'video',  'caption' => 'this is a test video', 'data' => $path_of_video_file);
$createPost = $client->createPost($blog, $post_data);
```