### PR TITLE
upgrade to phpunit 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: php
 before_script: composer install
 
 php:
-  - 7.1
   - 7.0
-  - 5.6
+  - 7.1
+  - 7.2
+  - 7.3
   - hhvm
 
 matrix:

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,9 @@
 {
 
   "name": "tumblr/tumblr",
-
   "description": "Official Tumblr PHP Client",
-
   "keywords": ["tumblr", "api", "sdk", "gif"],
-
   "homepage": "https://github.com/tumblr/tumblr.php",
-
   "authors": [
     {
       "name": "John Crepezzi",
@@ -16,24 +12,18 @@
       "role": "developer"
     }
   ],
-
   "license": "Apache-2.0",
-
   "type": "library",
-
   "require": {
     "eher/oauth": "1.0.*",
     "guzzlehttp/guzzle": "6.*"
   },
-
   "require-dev": {
-    "phpunit/phpunit": "5.3.*"
+    "phpunit/phpunit": "^6"
   },
-
   "autoload": {
     "psr-0": {
       "Tumblr\\API": "lib"
     }
   }
-
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,15 +1,29 @@
-<phpunit bootstrap="test/bootstrap.php" colors="true">
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+    backupGlobals="false"
+    backupStaticAttributes="false"
+    bootstrap="test/bootstrap.php"
+    colors="true"
+    convertErrorsToExceptions="true"
+    convertNoticesToExceptions="true"
+    convertWarningsToExceptions="true"
+    processIsolation="false"
+    stopOnFailure="false"
+>
     <testsuites>
-        <testsuite name="Tumblr SDK for PHP - Test Suite">
-            <directory>test</directory>
+        <testsuite name="Tumblr SDK for PHP">
+            <directory suffix=".php">./test</directory>
         </testsuite>
     </testsuites>
+
+    <logging>
+        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
+        <log type="coverage-html" target="./coverage" showUncoveredFiles="true"/>
+    </logging>
+
     <filter>
         <whitelist>
-            <directory suffix=".php">lib</directory>
+            <directory>./lib</directory>
         </whitelist>
     </filter>
-    <logging>
-        <log type="coverage-html" target="./coverage" highlight="true"/>
-    </logging>
 </phpunit>

--- a/test/RequestExceptionTest.php
+++ b/test/RequestExceptionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class RequestExceptionTest extends PHPUnit_Framework_TestCase
+class RequestExceptionTest extends PHPUnit\Framework\TestCase
 {
     public function provider()
     {

--- a/test/RequestHandlerTest.php
+++ b/test/RequestHandlerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class RequestHandlerTest extends \PHPUnit_Framework_TestCase
+class RequestHandlerTest extends PHPUnit\Framework\TestCase
 {
     public function testBaseUrlHasTrailingSlash()
     {

--- a/test/TumblrTest.php
+++ b/test/TumblrTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class TumblrTest extends PHPUnit_Framework_TestCase
+class TumblrTest extends PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider providerCalls
@@ -11,7 +11,10 @@ class TumblrTest extends PHPUnit_Framework_TestCase
         $response = $this->getResponseMock($which_mock);
 
         // Create request mock and set it to check for the proper response
-        $request = $this->getMock('Tumblr\API\RequestHandler', array('request'));
+        $request = $this->getMockBuilder(Tumblr\API\RequestHandler::class)
+            ->setMethods(['request'])
+            ->getMock();
+
         $request->expects($this->once())
             ->method('request')
             ->with($this->equalTo($type), $this->equalTo($path), $this->equalTo($params))


### PR DESCRIPTION
This upgrades phpunit to version 6, which requires dropping support for php 5.

@komapa thoughts on this? php 5.6 was eol'd at the beginning of the year.