### PR TITLE
Add data structure for NPF Content Blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ usage.php
 
 vendor
 composer.lock
+.phpunit.result.cache
+.idea/*

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
   },
 
   "require-dev": {
-    "phpunit/phpunit": "5.3.*"
+    "phpunit/phpunit": "^8"
   },
 
   "autoload": {

--- a/lib/Tumblr/API/Client.php
+++ b/lib/Tumblr/API/Client.php
@@ -211,8 +211,13 @@ class Client
     public function editPost($blogName, $postId, NPFScheme $data)
     {
         $data->id = $postId;
-        $path = $this->blogPath($blogName, '/post/edit');
+        $path = $this->blogPath($blogName, '/posts/'.$postId);
+        return $this->postRequest($path, $data->toJSON(), false);
+    }
 
+    public function editLegacyPost($blogName, $postId, $data) {
+        $data['id'] = $postId;
+        $path = $this->blogPath($blogName, '/post/edit');
         return $this->postRequest($path, $data, false);
     }
 
@@ -226,6 +231,12 @@ class Client
      */
     public function createPost($blogName, NPFScheme $data)
     {
+        $path = $this->blogPath($blogName, '/posts');
+
+        return $this->postRequest($path, $data->toJSON(), false);
+    }
+
+    public function createLegacyPost($blogName, $data) {
         $path = $this->blogPath($blogName, '/post');
 
         return $this->postRequest($path, $data, false);

--- a/lib/Tumblr/API/Client.php
+++ b/lib/Tumblr/API/Client.php
@@ -2,13 +2,16 @@
 
 namespace Tumblr\API;
 
+use Tumblr\API\NPF\Write\NPFScheme;
+use Tumblr\API\NPF\Write\NPFReblogScheme;
+
 /**
  * A client to access the Tumblr API
  */
 class Client
 {
 
-    private $apiKey;
+    private string $apiKey;
 
     /**
      * Create a new Client
@@ -18,7 +21,7 @@ class Client
      * @param string $token          oauth token
      * @param string $secret         oauth token secret
      */
-    public function __construct($consumerKey, $consumerSecret = null, $token = null, $secret = null)
+    public function __construct(string $consumerKey, string $consumerSecret = null, string $token = null, string $secret = null)
     {
         $this->requestHandler = new RequestHandler();
         $this->setConsumer($consumerKey, $consumerSecret);
@@ -205,9 +208,9 @@ class Client
      *
      * @return array the response array
      */
-    public function editPost($blogName, $postId, $data)
+    public function editPost($blogName, $postId, NPFScheme $data)
     {
-        $data['id'] = $postId;
+        $data->id = $postId;
         $path = $this->blogPath($blogName, '/post/edit');
 
         return $this->postRequest($path, $data, false);
@@ -221,7 +224,7 @@ class Client
      *
      * @return array the response array
      */
-    public function createPost($blogName, $data)
+    public function createPost($blogName, NPFScheme $data)
     {
         $path = $this->blogPath($blogName, '/post');
 

--- a/lib/Tumblr/API/NPF/Content/Attribution/AppAttribution.php
+++ b/lib/Tumblr/API/NPF/Content/Attribution/AppAttribution.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tumblr\API\NPF\Content\Attribution;
+
+use Tumblr\API\NPF\Content\Attribution\AttributionObject;
+use Tumblr\API\NPF\Content\Attribution\AttributionTypes;
+use Tumblr\API\NPF\Content\MediaBlock;
+
+class AppAttribution extends AttributionObject{
+    use Tumblr\API\NPF\Content\ValidURL;
+
+    protected string $url;
+    protected string $app_name;
+    protected string $display_text;
+    protected MediaBlock $logo;
+
+    public function __construct(string $url, string $app_name = "", string $display_text = "",
+                                MediaBlock $logo = null) {
+        parent::__construct(AttributionTypes.App);
+        $this->url = validURL($url);
+        $this->app_name = $app_name;
+        $this->display_text = $display_text;
+        $this->logo = $logo;
+    }
+}

--- a/lib/Tumblr/API/NPF/Content/Attribution/AttributionObject.php
+++ b/lib/Tumblr/API/NPF/Content/Attribution/AttributionObject.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tumblr\API\NPF\Content\Attribution;
+
+use Tumblr\API\NPF\Content\Attribution\AttributionType;
+
+abstract class AttributionObject {
+    protected string $type;
+
+    protected function __construct($type) {
+        $this->type = $type;
+    }
+
+    public function __get($property) {
+        if(\property_exists($this, $property)) {
+            return $this->$property;
+        }
+    }
+}

--- a/lib/Tumblr/API/NPF/Content/Attribution/AttributionTypes.php
+++ b/lib/Tumblr/API/NPF/Content/Attribution/AttributionTypes.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tumblr\API\NPF\Content\Attribution;
+
+class AttributionTypes {
+    const Link = "link";
+    const Blog = "blog";
+    const Post = "post";
+    const App = "app";
+}

--- a/lib/Tumblr/API/NPF/Content/Attribution/BlogAttribution.php
+++ b/lib/Tumblr/API/NPF/Content/Attribution/BlogAttribution.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tumblr\API\NPF\Content\Attribution;
+
+use Tumblr\API\NPF\Content\Attribution\AttributionObject;
+use Tumblr\API\NPF\Content\Attribution\AttributionTypes;
+
+class BlogAttribution extends AttributionObject{
+    protected object $blog;
+
+    public function __construct(object $blog) {
+        parent::__construct(AttributionTypes.Blog);
+        $this->blog = $blog;
+    }
+}

--- a/lib/Tumblr/API/NPF/Content/Attribution/LinkAttribution.php
+++ b/lib/Tumblr/API/NPF/Content/Attribution/LinkAttribution.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tumblr\API\NPF\Content\Attribution;
+
+use Tumblr\API\NPF\Content\Attribution\AttributionObject;
+use Tumblr\API\NPF\Content\Attribution\AttributionTypes;
+
+class LinkAttribution extends AttributionObject{
+    use Tumblr\API\NPF\Content\ValidURL;
+
+    protected string $url;
+
+    public function __construct(string $url) {
+        parent::__construct(AttributionTypes.Link);
+        $this->url = validURL($url);
+    }
+}

--- a/lib/Tumblr/API/NPF/Content/Attribution/PostAttribution.php
+++ b/lib/Tumblr/API/NPF/Content/Attribution/PostAttribution.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Tumblr\API\NPF\Content\Attribution;
+
+use Tumblr\API\NPF\Content\Attribution\AttributionObject;
+use Tumblr\API\NPF\Content\Attribution\AttributionTypes;
+
+class PostAttribution extends AttributionObject{
+    use Tumblr\API\NPF\Content\ValidURL;
+
+    protected string $url;
+    protected object $post;
+    protected object $blog;
+
+    public function __construct(string $url, object $post, object $blog) {
+        parent::__construct(AttributionTypes.Post);
+        $this->url = validURL($url);
+        $this->post = $post;
+        $this->blog = $blog;
+    }
+}

--- a/lib/Tumblr/API/NPF/Content/AudioBlock.php
+++ b/lib/Tumblr/API/NPF/Content/AudioBlock.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tumblr\API\NPF\Content;
+
+use Tumblr\API\NPF\Content\ContentBlock;
+use Tumblr\API\NPF\Content\Attribution\AttributionObject;
+use Tumblr\API\NPF\Content\MediaBlock;
+use Tumblr\API\NPF\Exception\InvalidURLException;
+
+class AudioBlock extends ContentBlock {
+    use Tumblr\API\NPF\Content\ValidURL;
+    
+    protected string $url;
+    protected MediaBlock $media;
+    protected string $provider;
+    protected string $title;
+    protected string $artist;
+    protected string $album;
+    protected MediaBlock $poster;
+    protected string $embed_html;
+    protected string $embed_url;
+    protected array $metadata;
+    protected ArributionObject $attribution;
+
+    public function __construct(string $url = "", MediaBlock $media = null, string $provider = "",
+                                 string $title = "",string  $artist = "", string $album = "",
+                                 MediaBlock $poster = null, string $embed_html = "", string $embed_url = "",
+                                 object $metadata = null, AttibutionObject $attribution = null) {
+        parent::__construct("audio");
+        $this->url = validURL($url);
+        $this->media = $media;
+        $this->provider = $provider;
+        $this->title = $title;
+        $this->artist = $artist;
+        $this->album =  $album;
+        $this->poster = $poster;
+        $this->embed_html = $embed_html;
+        $this->embeb_url = validURL($embed_url);
+        $this->metadata = $metadata;
+        $this->attribution = $attribution;
+    }
+}

--- a/lib/Tumblr/API/NPF/Content/ContentBlock.php
+++ b/lib/Tumblr/API/NPF/Content/ContentBlock.php
@@ -14,4 +14,8 @@ abstract class ContentBlock {
             return $this->$property;
         }
     }
+
+    public function toJSON() {
+        return \get_object_vars($this);
+    }
 }

--- a/lib/Tumblr/API/NPF/Content/ContentBlock.php
+++ b/lib/Tumblr/API/NPF/Content/ContentBlock.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tumblr\API\NPF\Content;
+
+abstract class ContentBlock {
+    protected string $type;
+
+    protected function __construct($type) {
+        $this->type = $type;
+    }
+
+    public function __get($property) {
+        if(\property_exists($this, $property)) {
+            return $this->$property;
+        }
+    }
+}

--- a/lib/Tumblr/API/NPF/Content/EmbedIFrameBlock.php
+++ b/lib/Tumblr/API/NPF/Content/EmbedIFrameBlock.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tumblr\API\NPF\Content;
+
+use Tumblr\API\NPF\Content\ContentBlock;
+use Tumblr\API\NPF\Exception\InvalidURLException;
+
+class EmbedIFrameBlock extends ContentBlock {
+    protected string $url;
+    protected int $width;
+    protected int $height;
+
+    public function __construct($type = "", $url, $width = 540, $height = 405) {
+        parent::__construct($type);
+        if(\filter_var($source_url, FILTER_VALIDATE_URL))
+            $this->url = $url;
+        else 
+            throw new InvalidURLException($url . " is not a valid URL");
+        $this->width = $width;
+        $this->height = $height;
+    }
+}

--- a/lib/Tumblr/API/NPF/Content/ImageBlock.php
+++ b/lib/Tumblr/API/NPF/Content/ImageBlock.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tumblr\API\NPF\Content;
+
+use Tumblr\API\NPF\Content\ContentBlock;
+use Tumblr\API\NPF\Content\MediaBlock;
+use Tumblr\API\NPF\Content\Attribution\AttributionObject;
+
+class ImageBlock extends ContentBlock {
+    protected array $media;
+    protected array $colors;
+    protected string $feedback_token;
+    protected MediaBlock $poster;
+    protected AttributionObject $attribution;
+    protected string $alt_text;
+
+    public function __construct($media, $colors = [], $feedback_token = "", $poster = null, 
+                                $attribution = null, $alt_text = "") {
+        parent::__construct("image");
+        $this->media = $media;
+        $this->colors = $colors;
+        $this->$feedback_token = $feedback_token;
+        $this->post = $poster;
+        $this->attribution = $attribution;
+        $this->alt_text = $alt_text;
+    }
+
+}

--- a/lib/Tumblr/API/NPF/Content/LinkBlock.php
+++ b/lib/Tumblr/API/NPF/Content/LinkBlock.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tumblr\API\NPF\Content;
+
+use Tumblr\API\NPF\Content\ContentBlock;
+use Tumblr\API\NPF\Content\MediaBlock;
+use Tumblr\API\NPF\Exception\InvalidURLException;
+
+class LinkBlock extends ContentBlock {
+    protected string $url;
+    protected string $title;
+    protected string $description;
+    protected string $author;
+    protected string $site_name;
+    protected string $display_url;
+    protected MediaBlock $poster;
+
+    public function __construct($url, $title = "", $description = "", $author = "",
+                                $site_name = "", $display_url = "", $poster = null) {
+        parent::__construct("link");
+        $this->url = $this->validURL($url);
+        $this->title = $title;
+        $this->description = $description;
+        $this->author = $author;
+        $this->site_name = $site_name;
+        $this->display_url = $display_url;
+        $this->poster = $poster;
+    }
+
+    protected function validURL($url) {
+        if(\filter_var($source_url, FILTER_VALIDATE_URL))
+            return $url;
+        else 
+            throw new InvalidURLException($url . " is not a valid URL");
+    }
+}

--- a/lib/Tumblr/API/NPF/Content/MediaBlock.php
+++ b/lib/Tumblr/API/NPF/Content/MediaBlock.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tumblr\API\NPF\Content;
+
+use Tumblr\API\NPF\Content\ContentBlock;
+use Tumblr\API\NPF\Exception\InvalidURLException;
+
+class MediaBlock extends ContentBlock {
+    protected string $url;
+    protected int $width;
+    protected int $height;
+    protected boolean $original_dimensions_missing;
+    protected boolean $cropped;
+    protected boolean $has_original_dimensions;
+
+    public function __construct($type = "", $url, $width = 540, $height = 405,
+                                 $original_dimensions_missing = false,
+                                 $cropped = false,
+                                 $has_original_dimensions = false) {
+        parent::__construct($type);
+        if(\filter_var($source_url, FILTER_VALIDATE_URL))
+            $this->url = $url;
+        else 
+            throw new InvalidURLException($url . " is not a valid URL");
+        $this->width = $width;
+        $this->height = $height;
+        $this->original_dimensions_missing = $original_dimensions_missing;
+        $this->cropped = $cropped;
+        $this->has_original_dimensions = $has_original_dimensions;
+    }
+}

--- a/lib/Tumblr/API/NPF/Content/MediaBlock.php
+++ b/lib/Tumblr/API/NPF/Content/MediaBlock.php
@@ -9,9 +9,9 @@ class MediaBlock extends ContentBlock {
     protected string $url;
     protected int $width;
     protected int $height;
-    protected boolean $original_dimensions_missing;
-    protected boolean $cropped;
-    protected boolean $has_original_dimensions;
+    protected bool $original_dimensions_missing;
+    protected bool $cropped;
+    protected bool $has_original_dimensions;
 
     public function __construct($type = "", $url, $width = 540, $height = 405,
                                  $original_dimensions_missing = false,

--- a/lib/Tumblr/API/NPF/Content/TextBlock.php
+++ b/lib/Tumblr/API/NPF/Content/TextBlock.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Tumblr\API\NPF\Content;
+
+use Tumblr\API\NPF\Content\ContentBlock;
+use Tumblr\API\NPF\Content\TextBlockSubtypes;
+use Tumblr\API\NPF\Exception\InvalidSubtypeException;
+
+class TextBlock extends ContentBlock {
+    protected string $text;
+    protected string $subtype;
+    protected array $formatting;
+
+    public function __construct($text, $subtype = "", $formatting = []) {
+        parent::__construct("text");
+        $this->text = $text;
+        $this->validSubtype($subtype);
+        $this->subtype = $subtype;
+        $this->formatting = $formatting;
+    }
+
+    protected function validSubtype($subtype) {
+        if(!in_array($subtype, TextBlockSubtypes::get()) && $subtype !== "") {
+            throw new InvalidSubtypeException($subtype . "is not a valid subtype");
+        }
+    }
+}

--- a/lib/Tumblr/API/NPF/Content/TextBlock.php
+++ b/lib/Tumblr/API/NPF/Content/TextBlock.php
@@ -20,7 +20,7 @@ class TextBlock extends ContentBlock {
     }
 
     protected function validSubtype($subtype) {
-        if(!in_array($subtype, TextBlockSubtypes::get()) && $subtype !== "") {
+        if(!\in_array($subtype, TextBlockSubtypes::get()) && $subtype !== "") {
             throw new InvalidSubtypeException($subtype . "is not a valid subtype");
         }
     }

--- a/lib/Tumblr/API/NPF/Content/TextBlockSubtypes.php
+++ b/lib/Tumblr/API/NPF/Content/TextBlockSubtypes.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Tumblr\API\NPF\Content;
+
+use Tumblr\API\NPF\Content\ContentBlock;
+
+class TextBlockSubtypes {
+    public static function get() {
+        return ["heading1",
+            "heading2",
+            "quirky",
+            "quote",
+            "indented",
+            "chat",
+            "ordered-list-item",
+            "unordered-list-item"];
+    }
+}

--- a/lib/Tumblr/API/NPF/Content/ValidURL.php
+++ b/lib/Tumblr/API/NPF/Content/ValidURL.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tumblr\API\NPF\Content;
+
+trait ValidURL {
+    function validURL(string $url) {
+        if(\filter_var($url, FILTER_VALIDATE_URL) || $url === "")
+            return $url;
+        else 
+            throw new InvalidURLException($url . " is not a valid URL");
+    }
+}

--- a/lib/Tumblr/API/NPF/Content/VideoBlock.php
+++ b/lib/Tumblr/API/NPF/Content/VideoBlock.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tumblr\API\NPF\Content;
+
+use Tumblr\API\NPF\Content\ContentBlock;
+use Tumblr\API\NPF\Content\Attribution\AttributionObject;
+use Tumblr\API\NPF\Content\MediaBlock;
+use Tumblr\API\NPF\Content\EmbedIFrameBlock;
+use Tumblr\API\NPF\Exception\InvalidURLException;
+
+class VideoBlock extends ContentBlock {
+    use Tumblr\API\NPF\Content\ValidURL;
+    
+    protected string $url;
+    protected MediaBlock $media;
+    protected string $provider;
+    protected MediaBlock $poster;
+    protected string $embed_html;
+    protected string $embed_url;
+    protected EmbedIFrameBlock $embed_iframe;
+    protected array $metadata;
+    protected ArributionObject $attribution;
+    protected boolean $can_autoplay_on_cellular;
+
+    public function __construct(string $url = "", MediaBlock $media = null, string $provider = "",
+                                 MediaBlock $poster = null, string $embed_html = "", string $embed_url = "",
+                                 EmbedIFrameBlock $embed_iframe = null, object $metadata = null, 
+                                 AttibutionObject $attribution = null, $can_autoplay_on_cellular = false) {
+        parent::__construct("video");
+        $this->url = validURL($url);
+        $this->media = $media;
+        $this->provider = $provider;
+        $this->poster = $poster;
+        $this->embed_html = $embed_html;
+        $this->embeb_url = validURL($embed_url);
+        $this->embed_iframe = $embed_iframe;
+        $this->metadata = $metadata;
+        $this->attribution = $attribution;
+        $this->can_autoplay_on_cellular = $can_autoplay_on_cellular;
+    }
+}

--- a/lib/Tumblr/API/NPF/Content/VideoBlock.php
+++ b/lib/Tumblr/API/NPF/Content/VideoBlock.php
@@ -20,7 +20,7 @@ class VideoBlock extends ContentBlock {
     protected EmbedIFrameBlock $embed_iframe;
     protected array $metadata;
     protected ArributionObject $attribution;
-    protected boolean $can_autoplay_on_cellular;
+    protected bool $can_autoplay_on_cellular;
 
     public function __construct(string $url = "", MediaBlock $media = null, string $provider = "",
                                  MediaBlock $poster = null, string $embed_html = "", string $embed_url = "",

--- a/lib/Tumblr/API/NPF/Exception/InvalidSubtypeException.php
+++ b/lib/Tumblr/API/NPF/Exception/InvalidSubtypeException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Tumblr\API\NFP\Exception;
+
+class InvalidSubtypeException extends \Exception {
+    public function __construct($message, $code = 0, Exception $previous = null) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/lib/Tumblr/API/NPF/Exception/InvalidURLException.php
+++ b/lib/Tumblr/API/NPF/Exception/InvalidURLException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Tumblr\API\NFP\Exception;
+
+class InvalidURLException extends \Exception {
+    public function __construct($message, $code = 0, Exception $previous = null) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/lib/Tumblr/API/NPF/Read/PostFormat.php
+++ b/lib/Tumblr/API/NPF/Read/PostFormat.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tumblr\API\NPF\Read;
+
+class PostFormat {
+    protected string $object_type;
+    protected string $type;
+    protected string $id;
+    protected string $tumblelog_uuid;
+    protected string $reblog_key;
+    protected array $trail;
+    protected array $content;
+    protected array $layout;
+
+    protected function __construct(string $object_type, string $type, $id, string $tumblelog_uuid, 
+                                 string $reblog_key, array $trail = [], array $content = [], array $layout = []){
+        $this->object_type = $object_type;
+        $this->type = $type;
+        $this->id = $id;
+        $this->tumblelog_uuid = $tumblelog_uuid;
+        $this->reblog_key = $reblog_key;
+        $this->trail = $trail;
+        $this->content = $content;
+        $this->layout = $layout;
+    }
+
+    public function __get($property) {
+        if(\property_exists($this, $property)) {
+            return $this->$property;
+        }
+    }
+}

--- a/lib/Tumblr/API/NPF/Read/ReblogPostFormat.php
+++ b/lib/Tumblr/API/NPF/Read/ReblogPostFormat.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Tumblr\API\NPF\Read;
+
+use Tumblr\API\NPF\Read\PostFormat;
+
+class ReblogPostFormat extends PostFormat {
+    protected string $parent_post_id;
+    protected string $parent_tumblelog_uuid;
+
+    protected function __construct(string $object_type, string $type, $id, string $tumblelog_uuid, 
+                                   string $reblog_key, array $trail = [], array $content = [], array $layout = [],
+                                   string $parent_tumblelog_uuid, string $parent_post_id) {
+        parent::construct($object_type, $type, $id, $tumblelog_uuid, 
+                          $reblog_key, $trail, $content, $layout);
+        $this->parent_post_id = $parent_post_id;
+        $this->parent_tumblelog_uuid = $parent_tumblelog_uuid;
+    }
+}

--- a/lib/Tumblr/API/NPF/Write/NPFCreateState.php
+++ b/lib/Tumblr/API/NPF/Write/NPFCreateState.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tumblr\API\NPF\Write;
+
+abstract class NPFCreateState {
+    const Published = "published";
+    const Queue = "queue";
+    const Draft = "draft";
+    const Private = "private";
+}

--- a/lib/Tumblr/API/NPF/Write/NPFReblogScheme.php
+++ b/lib/Tumblr/API/NPF/Write/NPFReblogScheme.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tumblr\API\NPF\Write;
+
+use Tumblr\API\NPF\Write\NPFScheme;
+
+class NPFReblogScheme extends NPFScheme {
+    protected string $parent_tumblelog_uuid;
+    protected int $parent_post_id;
+    protected string $reblog_key;
+    protected boolean $hide_trail;
+
+    public function  __construct($content, $layout= [], 
+                        $state = NPFCreateState.Published,
+                        $publish_on = NULL, 
+                        $tags = NULL,
+                        $source_url = NULL,
+                        $send_to_twitter = false,
+                        $send_to_facebook = false,
+                        $parent_tumblelog_uuid,
+                        $parent_post_id,
+                        $reblog_key,
+                        $hide_trail = false) {
+        parent::construct($content, $layout, $state, $publish_on, 
+                          $tags, $source_url, $send_to_twitter, $send_to_facebook);
+        $this->parent_tumblelog_uuid = $parent_tumblelog_uuid;
+        $this->parent_post_id = $parent_post_id;
+        $this->reblog_key = $reblog_key;
+       $this->hide_trail = $hide_trail;
+    }
+
+    public function toJSON() {
+        return \json_encode(array_merge($this->toArray(), parent::toArray()));
+    }
+
+    protected function toArray() {
+        return [
+            "parent_tumblelog_uuid" => $this->parent_tumblelog_uuid,
+            "parent_post_id" => $this->parent_post_id,
+            "reblog_key" => $this->reblog_key,
+            "hide_trail" => $this->hide_trail
+        ];
+    }
+}

--- a/lib/Tumblr/API/NPF/Write/NPFReblogScheme.php
+++ b/lib/Tumblr/API/NPF/Write/NPFReblogScheme.php
@@ -8,10 +8,10 @@ class NPFReblogScheme extends NPFScheme {
     protected string $parent_tumblelog_uuid;
     protected int $parent_post_id;
     protected string $reblog_key;
-    protected boolean $hide_trail;
+    protected bool $hide_trail;
 
     public function  __construct($content, $layout= [], 
-                        $state = NPFCreateState.Published,
+                        $state = NPFCreateState::Published,
                         $publish_on = NULL, 
                         $tags = NULL,
                         $source_url = NULL,

--- a/lib/Tumblr/API/NPF/Write/NPFScheme.php
+++ b/lib/Tumblr/API/NPF/Write/NPFScheme.php
@@ -6,21 +6,21 @@ use Tumblr\API\NPF\Write\NPFCreateState;
 use Tumblr\API\NPF\Exception\InvalidURLException;
 
 class NPFScheme {
-    protected string $id;
+    protected $id;
     protected Array $content;
     protected Array $layout;
     protected string $state;
     protected string $publish_on;
     protected string $tags;
     protected string $source_url;
-    protected boolean $send_to_twitter;
-    protected boolean $send_to_facebook;
+    protected bool $send_to_twitter;
+    protected bool $send_to_facebook;
 
-    public function __construct($id = null, $content, $layout= [], 
-        $state = NPFCreateState.Published,
-        $publish_on = NULL, 
-        $tags = NULL,
-        $source_url = NULL,
+    public function __construct($id = '', $content, $layout= [], 
+        $state = NPFCreateState::Published,
+        $publish_on = '', 
+        $tags = '',
+        $source_url = '',
         $send_to_twitter = false,
         $send_to_facebook = false) {
             $this->id = $id;
@@ -29,7 +29,7 @@ class NPFScheme {
             $this->state = $state;
             $this->publish_on = ($publish_on === NULL? \date('l jS \of F Y h:i:s A') : $publish_on);
             $this->tags = $tags;
-            $this->source_url = (\filter_var($source_url, FILTER_VALIDATE_URL) ? $source_url : NULL);
+            $this->source_url = (\filter_var($source_url, FILTER_VALIDATE_URL) ? $source_url : "");
             $this->send_to_twitter = $send_to_twitter;
             $this->send_to_facebook = $send_to_facebook;
     }
@@ -59,7 +59,7 @@ class NPFScheme {
 
     protected function toArray() {
         return [
-            "content" => $this->content,
+            "content" => $this->serializeArrayOfObjects($this->content),
             "layout" => $this->layout,
             "state" => $this->state,
             "publish_on" => $this->publish_on,
@@ -68,5 +68,14 @@ class NPFScheme {
             "send_to_twitter" => $this->send_to_twitter,
             "send_to_facebook" => $this->send_to_facebook
         ];
+    }
+
+    protected function serializeArrayOfObjects($array) {
+        $data = [];
+        foreach($array as $field) {
+            array_push($data, $field->toJSON());
+        }
+
+        return $data;
     }
 }

--- a/lib/Tumblr/API/NPF/Write/NPFScheme.php
+++ b/lib/Tumblr/API/NPF/Write/NPFScheme.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tumblr\API\NPF\Write;
+
+use Tumblr\API\NPF\Write\NPFCreateState;
+use Tumblr\API\NPF\Exception\InvalidURLException;
+
+class NPFScheme {
+    protected string $id;
+    protected Array $content;
+    protected Array $layout;
+    protected string $state;
+    protected string $publish_on;
+    protected string $tags;
+    protected string $source_url;
+    protected boolean $send_to_twitter;
+    protected boolean $send_to_facebook;
+
+    public function __construct($id = null, $content, $layout= [], 
+        $state = NPFCreateState.Published,
+        $publish_on = NULL, 
+        $tags = NULL,
+        $source_url = NULL,
+        $send_to_twitter = false,
+        $send_to_facebook = false) {
+            $this->id = $id;
+            $this->content = $content;
+            $this->layout = $layout;
+            $this->state = $state;
+            $this->publish_on = ($publish_on === NULL? \date('l jS \of F Y h:i:s A') : $publish_on);
+            $this->tags = $tags;
+            $this->source_url = (\filter_var($source_url, FILTER_VALIDATE_URL) ? $source_url : NULL);
+            $this->send_to_twitter = $send_to_twitter;
+            $this->send_to_facebook = $send_to_facebook;
+    }
+
+    public function toJSON(): string {
+        return \json_encode($this->toArray());
+    }
+
+    public function __get($property) {
+        if(\property_exists($this, $property)) {
+            return $this->$property;
+        }
+    }
+
+    public function __set($property, $value) {
+        if($property == "source_url") {
+            if(\filter_var($source_url, FILTER_VALIDATE_URL))
+                $this->$property = $value;
+            else
+                throw new InvalidURLException($value . " is not a valid URL");
+        }else if (\property_exists($this, $property)) {
+            $this->$property = $value;
+        }
+      
+        return $this;
+    }
+
+    protected function toArray() {
+        return [
+            "content" => $this->content,
+            "layout" => $this->layout,
+            "state" => $this->state,
+            "publish_on" => $this->publish_on,
+            "tags" => $this->tags,
+            "source_url" => $this->source_url,
+            "send_to_twitter" => $this->send_to_twitter,
+            "send_to_facebook" => $this->send_to_facebook
+        ];
+    }
+}

--- a/lib/Tumblr/API/RequestHandler.php
+++ b/lib/Tumblr/API/RequestHandler.php
@@ -30,6 +30,12 @@ class RequestHandler
         ));
     }
 
+    public function __get($property) {
+        if(property_exists($this, $property)) {
+            return $this->$property;
+        }
+    }
+
     /**
      * Set the consumer for this request handler
      *
@@ -70,11 +76,12 @@ class RequestHandler
     /**
      * Make a request with this request handler
      *
-     * @param string $method  one of GET, POST
-     * @param string $path    the path to hit
-     * @param array  $options the array of params
+     * @param string $method one of GET, POST
+     * @param string $path the path to hit
+     * @param array $options the array of params
      *
      * @return \stdClass response object
+     * @throws \Eher\OAuth\OAuthException
      */
     public function request($method, $path, $options)
     {

--- a/test/BlockSerialization/TextBlockSerializationTest.php
+++ b/test/BlockSerialization/TextBlockSerializationTest.php
@@ -1,0 +1,12 @@
+<?php
+
+class TextBlockSerializationTest extends \PHPUnit\Framework\TestCase
+{
+    public function testSerializesValidModel() {
+        $model = new \Tumblr\API\NPF\Content\TextBlock("Hello World");
+        $result = $model->toJSON();
+        $this->assertEquals($result['text'], "Hello World");
+        $this->assertEquals($result['subtype'],  null);
+        $this->assertEquals($result['formatting'], []);
+    }
+}

--- a/test/PostTest.php
+++ b/test/PostTest.php
@@ -1,12 +1,17 @@
 <?php
 
+use Tumblr\API\NPF\Write\NPFScheme;
+use Tumblr\API\NPF\Content\TextBlock;
+
 class PostTest extends TumblrTest
 {
     public function providerCalls()
     {
         return array(
 
-            // delete post
+            /**
+             * Execute delete request for existing post
+             */
             array(function ($c) { $c->deletePost('b', 123, 'abc'); }, 'POST', 'v2/blog/b.tumblr.com/post/delete', array('id' => 123, 'reblog_key' => 'abc')),
 
             // reblog post
@@ -14,16 +19,27 @@ class PostTest extends TumblrTest
             array(function ($c) { $c->reblogPost('b', 123, 'abc', array('something' => 'else')); }, 'POST', 'v2/blog/b.tumblr.com/post/reblog', array('id' => 123, 'reblog_key' => 'abc', 'something' => 'else')),
 
             // edit post
-            array(function ($c) { $c->editPost('b.n', 123, array('d' => 'ata')); }, 'POST', 'v2/blog/b.n/post/edit', array('d' => 'ata', 'id' => 123)),
+            array(function ($c) { $c->editPost('b.n', 123, new NPFScheme(null, [
+                new TextBlock("Hello World")
+            ])); 
+            }, 
+            'POST', 'v2/blog/b.n/posts/123',
+            '{"content":[{"text":"Hello World","subtype":"","formatting":[],"type":"text"}],"layout":[],"state":"published","publish_on":"","tags":"","source_url":"","send_to_twitter":false,"send_to_facebook":false}'),
+
+            array(function ($c) { $c->editLegacyPost('b.n', 123, array('source' => 'remote')); }, 'POST', 'v2/blog/b.n/post/edit', array('source' => 'remote', 'id' => 123)),
 
             // create post
-            array(function ($c) { $c->createPost('b.n', array('d' => 'ata')); }, 'POST', 'v2/blog/b.n/post', array('d' => 'ata')),
+            array(function ($c) { $c->createPost('b.n', new NPFScheme(null, [
+                    new TextBlock("Hello World")
+                ]));
+                }, 'POST', 'v2/blog/b.n/posts',
+                '{"content":[{"text":"Hello World","subtype":"","formatting":[],"type":"text"}],"layout":[],"state":"published","publish_on":"","tags":"","source_url":"","send_to_twitter":false,"send_to_facebook":false}'),
 
             // single source
-            array(function ($c) { $c->createPost('b.n', array('source' => 'remote')); }, 'POST', 'v2/blog/b.n/post', array('source' => 'remote')),
+            array(function ($c) { $c->createLegacyPost('b.n', array('source' => 'remote')); }, 'POST', 'v2/blog/b.n/post', array('source' => 'remote')),
 
             // multi-source
-            array(function ($c) { $c->createPost('b.n', array('source' => array('r1', 'r2'))); }, 'POST', 'v2/blog/b.n/post', array('source[0]' => 'r1', 'source[1]' => 'r2')),
+            array(function ($c) { $c->createLegacyPost('b.n', array('source' => array('r1', 'r2'))); }, 'POST', 'v2/blog/b.n/post', array('source[0]' => 'r1', 'source[1]' => 'r2')),
 
         );
     }

--- a/test/RequestExceptionTest.php
+++ b/test/RequestExceptionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class RequestExceptionTest extends PHPUnit_Framework_TestCase
+class RequestExceptionTest extends \PHPUnit\Framework\TestCase
 {
     public function provider()
     {

--- a/test/RequestHandlerTest.php
+++ b/test/RequestHandlerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class RequestHandlerTest extends \PHPUnit_Framework_TestCase
+class RequestHandlerTest extends \PHPUnit\Framework\TestCase
 {
     public function testBaseUrlHasTrailingSlash()
     {

--- a/test/RequestHandlerTest.php
+++ b/test/RequestHandlerTest.php
@@ -9,15 +9,12 @@ class RequestHandlerTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('Tumblr\API\RequestHandler', $rh);
 
         $rh->setBaseUrl('http://example.com');
-        $this->assertAttributeEquals('http://example.com/', 'baseUrl', $rh);
+        $this->assertEquals('http://example.com/', $rh->baseUrl);
 
         $rh->setBaseUrl('http://example.com/');
-        $this->assertAttributeEquals('http://example.com/', 'baseUrl', $rh);
+        $this->assertEquals('http://example.com/', $rh->baseUrl);
     }
 
-     /**
-     * @expectedException GuzzleHttp\Exception\ConnectException
-     */
     public function testRequestThrowsErrorOnMalformedBaseUrl()
     {
         $client = new Tumblr\API\Client(API_KEY);
@@ -25,16 +22,11 @@ class RequestHandlerTest extends \PHPUnit\Framework\TestCase
         $rh->setBaseUrl('this is a malformed URL!');
 
         $options = array('some kinda option');
-
+        $this->expectException(GuzzleHttp\Exception\ConnectException::class);
         $rh->request('GET', 'foo', $options);
 
     }
 
-    /**
-     * @expectedException Tumblr\API\RequestException
-     * @expectedExceptionCode 400
-     * @expectedExceptionMessage Sadface
-     */
     public function testRequestThrowsOnBadResponse()
     {
         // Setup mock handler and response
@@ -48,6 +40,9 @@ class RequestHandlerTest extends \PHPUnit\Framework\TestCase
         $client = new Tumblr\API\Client(API_KEY);
         $client->getRequestHandler()->client = $guzzle;
 
+        $this->expectException(Tumblr\API\RequestException::class);
+        $this->expectExceptionCode(400);
+        $this->expectExceptionMessage("Sadface");
         // Throws because it got a 400 back
         $client->getBlogInfo('ceyko.tumblr.com');
     }

--- a/test/TumblrTest.php
+++ b/test/TumblrTest.php
@@ -1,6 +1,7 @@
 <?php
+use Tumblr\API\RequestHandler;
 
-class TumblrTest extends PHPUnit_Framework_TestCase
+class TumblrTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider providerCalls
@@ -11,7 +12,7 @@ class TumblrTest extends PHPUnit_Framework_TestCase
         $response = $this->getResponseMock($which_mock);
 
         // Create request mock and set it to check for the proper response
-        $request = $this->getMock('Tumblr\API\RequestHandler', array('request'));
+        $request = $this->createMock(RequestHandler::class);
         $request->expects($this->once())
             ->method('request')
             ->with($this->equalTo($type), $this->equalTo($path), $this->equalTo($params))

--- a/test/TumblrTest.php
+++ b/test/TumblrTest.php
@@ -49,4 +49,20 @@ class TumblrTest extends \PHPUnit\Framework\TestCase
         return $response;
     }
 
+    private function prepareGuzzleClient($type, $path, $params, $response) {
+        // Create request mock and set it to check for the proper response
+        $request = $this->createMock(RequestHandler::class);
+        $request->expects($this->once())
+            ->method('request')
+            ->with($this->equalTo($type), $this->equalTo($path), $this->equalTo($params))
+            ->will($this->returnValue($response));
+
+        // Create a new client and set it up to use that request handler
+        $client = new Tumblr\API\Client(API_KEY);
+        $ref = new ReflectionObject($client);
+        $prop = $ref->getProperty('requestHandler');
+        $prop->setAccessible(true);
+        $prop->setValue($client, $request);
+    }
+
 }


### PR DESCRIPTION
As a developer, I really like to get a very good idea about the hows and whats regarding the data I need to send to an API.
At this point either API documentation (e.g. OpenAPI, JSON API, etc.) or a very well structured client implementation provides the necessary insights.

This is why I want to propose a structure of PHP classes with typed properties for making the use of the API client more intuitive and easy to use - especially with the structural requirements and constraints introduced with NPF.

To further improve the developer experience for creating instances of the sometimes complex structures of NPF, a system of builder implementations additionally supporting this process will be introduced.

**Disclaimer: This pull request is not yet ready for merge but should provide first insights into the ongoing development.**
Please feel free to comment your ideas or critique 😁