### PR TITLE
Update .travis.yml to test under PHP 7.2-7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,14 @@ language: php
 before_script: composer install
 
 php:
-  - 7.1
-  - 7.0
   - 5.6
-  - hhvm
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
+  - nightly
 
 matrix:
   allow_failures:
-    - php: hhvm
+    - php: nightly


### PR DESCRIPTION
This PR:
 - [x] Updates Travis CI to test under PHP 7.2+
 - [x] Drops support for HHVM.

