### PR TITLE
Add YAML validation workflow

### DIFF
--- a/.github/workflows/validate_yaml.yaml
+++ b/.github/workflows/validate_yaml.yaml
@@ -1,0 +1,20 @@
+# yamllint disable rule:line-length
+
+name: YAML Validation
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  validate-yaml:
+    name: Validate YAML
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run YAML linter
+        run: |
+          find . -path \*/vendor -prune -false -o -name \*.y*ml | xargs yamllint -d relaxed


### PR DESCRIPTION
This workflow will validate `.yaml` files for general correctness everywhere except for vendored dependencies

- It should also enable running other workflows, since IIRC unless there's a single workflow already no other workflow will run.
- GitHub doesn't do that last time I checked: if a workflow config has a syntax error, workflow does not run. 

#### Testing

The file itself should be valid YAML:
```
yamllint -d relaxed .github/workflows/validate_yaml.yaml
```
